### PR TITLE
Add a CI task to trigger probe-scraper

### DIFF
--- a/.github/workflows/glean-probe-scraper.yml
+++ b/.github/workflows/glean-probe-scraper.yml
@@ -1,0 +1,6 @@
+---
+name: Glean probe-scraper
+on: [push, pull_request]
+jobs:
+  glean-probe-scraper:
+    uses: mozilla/probe-scraper/.github/workflows/glean.yaml@main


### PR DESCRIPTION
This is required so that probe-scraper knows when those files change and so that it updates the probeinfo service. In turn this will create the ping tables for tiktok-report, email, etc.