### PR TITLE
[bugfix/app-use-no-encryption] set flag of app uses encryption to no

### DIFF
--- a/TikTok Reporter/TikTok ReporterShare/Info.plist
+++ b/TikTok Reporter/TikTok ReporterShare/Info.plist
@@ -24,6 +24,7 @@
 		<key>NSExtensionPrincipalClass</key>
 		<string>ShareViewController</string>
 	</dict>
+    <key>ITSAppUsesNonExemptEncryption</key><false/>
 	<key>UIAppFonts</key>
 	<array>
 		<string>ZillaSlab-Bold.ttf</string>


### PR DESCRIPTION
Added no encrpytion flag to plist so app store connect will not ask this value in prompt again
- set flag of app uses encryption to no