### PR TITLE
[bugfix/comment-clear] remove comments after publishing recording

### DIFF
--- a/TikTok Reporter/TikTok Reporter/UI/Screens/Main/Record/RecordViewModel.swift
+++ b/TikTok Reporter/TikTok Reporter/UI/Screens/Main/Record/RecordViewModel.swift
@@ -113,6 +113,8 @@ extension RecordView {
             }
 
             state = .loading
+            
+            videoComments = ""
 
             Task {
 


### PR DESCRIPTION
- the bug for comments field staying permanent after publishing recording has been fixed